### PR TITLE
Added Dockerfile, Makefile and updated README.md.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:14-alpine AS common
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+
+# Local development
+FROM common AS dev
+CMD ["npm", "start"]
+
+# Production build
+FROM common AS prod
+CMD ["npm", "run", "build"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: build
+.DEFAULT_GOAL := build-dev
+
+COMMIT_HASH=`git rev-parse --short HEAD`
+
+build-dev:
+	echo "Building trackavault ${COMMIT_HASH}-dev image as latest-dev..."
+	docker build --target dev -t trackavault:${COMMIT_HASH}-dev .
+	docker tag trackavault:${COMMIT_HASH}-dev trackavault:latest-dev
+
+build-prod:
+	echo "Building trackavault ${COMMIT_HASH}-prod image as prod..."
+	docker build --target prod -t trackavault:${COMMIT_HASH}-prod .
+	docker tag trackavault:${COMMIT_HASH}-prod trackavault:prod
+
+start-dev: stop
+	echo "Running trackavault latest-dev..."
+	@docker start trackavault-dev || docker run --rm -dit -p 4200:4200 \
+		--add-host=host.docker.internal:172.17.0.1 \
+		--name trackavault-dev \
+		--user $(id -u):$(id -g) \
+		-v ${CURDIR}:/usr/src/app \
+		trackavault:latest-dev
+
+start-prod: stop
+	echo "Running trackavault prod..."
+	@docker run --rm -dit \
+		-v ${CURDIR}:/usr/src/app \
+		trackavault:prod
+
+stop:
+	@docker stop trackavault-dev || true
+	sleep 5

--- a/README.md
+++ b/README.md
@@ -1,8 +1,38 @@
 # Trackavault UI
-## How to run locally
-- Clone repository
-- Install modules: ```npm install```
-- Copy the example environment from src/environments/environment.example.ts to src/environments/environment.ts
-- Run the app: ```npm run start```
-- Open Chrome with security disabled: ```C:\Program Files\Google\Chrome\Application\chrome.exe --user-data-dir=%localappdata%\Temp --disable-web-security --disable-site-isolation-trials```
-- Go to: http://localhost:4200
+
+## Development
+
+### Getting started
+
+- Clone the repository
+- `make -s build-dev`
+- `make -s start-dev`
+- Navigate to `https://localhost:4200`
+
+### Makefile
+
+These are the available targets for make:
+
+- `build-dev`
+
+  Builds the Docker image for the project (see Dockerfile).
+  The dev image is basically a Node container that prepares the project (installs dependencies).
+
+- `build-prod`
+
+  Builds the Docker image for the project (see Dockerfile).
+  The prod image is basically running `npm run build` on top of the dev image.
+
+- `start-dev`
+
+  Starts a Docker container with the latest dev image.
+  The tools needed for development like `npm` or `ng` will be run inside this container.
+
+- `start-prod`
+
+  Starts a Docker container with the prod image.
+  The container builds the Angular application and outputs to the `dist/` folder.
+
+- `stop`
+
+  Stops the Docker container

--- a/angular.json
+++ b/angular.json
@@ -68,7 +68,9 @@
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
-            "browserTarget": "portfolio-frontend:build"
+            "browserTarget": "portfolio-frontend:build",
+            "host": "0.0.0.0",
+            "ssl": true
           },
           "configurations": {
             "production": {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "portfolio-frontend",
   "version": "0.0.0",
   "scripts": {
-    "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
-    "test": "ng test",
-    "lint": "ng lint",
-    "e2e": "ng e2e",
-    "deploy-release": "ng deploy portfolio-frontend --configuration=release",
-    "deploy-staging": "ng deploy portfolio-frontend --configuration=staging",
-    "generate-favicon": "pwa-asset-generator ./build_assets/logo.svg ./src/assets -i ./src/index.html -m ./src/manifest.webmanifest --opaque false --icon-only --favicon --type png",
-    "generate-app-icons": "pwa-asset-generator ./build_assets/logo.svg ./src/assets -i ./src/index.html -m ./src/manifest.webmanifest --background \"#000\"",
-    "run": "ng build --prod && http-server -p 8080 -c-1 dist/portfolio-frontend"
+    "ng": "./node_modules/.bin/ng",
+    "start": "./node_modules/.bin/ng serve",
+    "build": "./node_modules/.bin/ng build",
+    "test": "./node_modules/.bin/ng test",
+    "lint": "./node_modules/.bin/ng lint",
+    "e2e": "./node_modules/.bin/ng e2e",
+    "deploy-release": "./node_modules/.bin/ng deploy portfolio-frontend --configuration=release",
+    "deploy-staging": "./node_modules/.bin/ng deploy portfolio-frontend --configuration=staging",
+    "generate-favicon": "./node_modules/.bin/pwa-asset-generator ./build_assets/logo.svg ./src/assets -i ./src/index.html -m ./src/manifest.webmanifest --opaque false --icon-only --favicon --type png",
+    "generate-app-icons": "./node_modules/.bin/pwa-asset-generator ./build_assets/logo.svg ./src/assets -i ./src/index.html -m ./src/manifest.webmanifest --background \"#000\"",
+    "run": "./node_modules/.bin/ng build --prod && http-server -p 8080 -c-1 dist/portfolio-frontend"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
**Abstract**
In order to standardize the local development environment I propose the use of Docker containers.
Dockerizing the application requires the use of several commands (build images, create container, stop, etc).
To avoid having to remember these commands, I propose a Makefile with several targets (build-dev, start-dev, etc).

**Done**
- added Dockerfile with the necessary instructions for building the `prod` and `dev` containers
- added Makefile with basic targets (build-dev + start-dev, build-prod + start-prod and stop)
- updated README.md

**Remarks**
- output of make targets could be prettier and less verbose
- noticed issues while compiling due to dependencies (chart.js, chartjs-plugin-autocolors, ng2-charts, ng2-tooltip-directive) that could be addressed in another PR